### PR TITLE
Document manual build steps without Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ For those who don't/can't use Julti/Jingle, it can be [downloaded as an applicat
 
 This repository no longer uses Gradle. Build the tracker with your preferred Java tooling (for example IntelliJ IDEA or direct `javac` invocations) and place the required dependency jars on the classpath. The application depends on Julti, Jingle, Gson, FlatLaf, the GitHub API client, and the IntelliJ GUI forms runtime. All of these jars can be obtained from the original tooling installations and reused locally for offline builds.
 
+For a command-line walkthrough that recreates the old Gradle workflow with plain `javac`/`jar` commands, see [`docs/building.md`](docs/building.md).
+
 When editing GUI forms in IntelliJ IDEA, make sure the IDE is configured to generate Java source code for forms:
 - `Settings` -> `Editor` -> `GUI Designer` -> `Generate GUI into: Java source code`
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,0 +1,83 @@
+# Building PaceMan Tracker without Gradle
+
+The Gradle build scripts were removed in favour of a lightweight manual
+workflow. The tracker can still be compiled from the command line as long as
+the necessary dependency jars are available locally.
+
+## 1. Collect dependencies
+
+The application requires the following third-party libraries:
+
+- **Julti** – provides most of the tracker integration points.
+- **Jingle** – contains the shared GUI widgets.
+- **Gson** – JSON parsing and serialisation.
+- **FlatLaf** – Swing look & feel.
+- **GitHub API client** – update checks.
+- **IntelliJ GUI forms runtime** – renders the `.form`-generated UI classes.
+
+Grab the jars from an existing Julti/Jingle installation or from a previously
+generated Gradle build and place them in a `lib/` directory in the repository
+root. The manual steps below assume `lib/` exists and contains all the jars.
+
+```
+PaceMan-Tracker/
+├── lib/
+│   ├── gson-*.jar
+│   ├── flatlaf-*.jar
+│   ├── julti-*.jar
+│   ├── jingle-*.jar
+│   ├── github-api-*.jar
+│   └── forms-rt.jar
+├── src/
+└── ...
+```
+
+## 2. Compile the sources
+
+Use the JDK's `javac` compiler and direct it to output the class files into a
+temporary build directory. The command below works on macOS/Linux shells; on
+Windows swap the classpath separator `:` for `;`.
+
+```bash
+mkdir -p build/classes
+find src/main/java -name "*.java" > build/sources.txt
+javac @build/sources.txt \
+      -d build/classes \
+      -cp "lib/*"
+```
+
+Copy the resource files so they are available on the runtime classpath:
+
+```bash
+rsync -a src/main/resources/ build/classes/
+```
+
+> Tip: replace `rsync` with `cp -R` on systems where `rsync` is not installed.
+
+## 3. Package a runnable jar (optional)
+
+If you want a single jar for distribution, package the compiled classes
+alongside the resources:
+
+```bash
+jar --create \
+    --file build/PaceManTracker.jar \
+    -C build/classes .
+```
+
+Launch the jar with the dependencies on the classpath:
+
+```bash
+java -cp "build/PaceManTracker.jar:lib/*" gg.paceman.tracker.PaceManTracker
+```
+
+## 4. Use IntelliJ IDEA instead
+
+IntelliJ IDEA can import the project as a plain Java project. Point the IDE to
+the `src/main/java` and `src/main/resources` directories, then add the jars from
+`lib/` as module dependencies. Make sure that `Settings → Editor → GUI Designer`
+is configured to "Generate GUI into: Java source code" so the IDE keeps the
+`.form` files and generated sources in sync.
+
+With the dependencies in place, IntelliJ can build and run the application via
+its standard Run/Debug configurations.


### PR DESCRIPTION
## Summary
- add a detailed `docs/building.md` guide that recreates the old Gradle workflow with plain JDK tools
- link the new build guide from the README so contributors can find it easily

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e687aebb50832b9279a835a0ea2f73